### PR TITLE
Prevent event reindexing (on same HS) by only allowing a cursor to change incrementally

### DIFF
--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -27,24 +27,33 @@ impl RedisOps for Homeserver {}
 impl Homeserver {
     /// Instantiates a new homeserver with default cursor
     pub fn new(id: PubkyId) -> Self {
+        // TODO validate_cursor_change
         Homeserver { id, cursor: 0 }
     }
 
     /// Creates a new homeserver instance with the specified cursor
-    pub fn try_from_cursor<T: Into<String>>(id: PubkyId, cursor_str: T) -> Result<Self, DynError> {
+    pub async fn try_from_cursor<T: Into<String>>(
+        id: PubkyId,
+        cursor_str: T,
+    ) -> Result<Self, DynError> {
         let cursor_str = cursor_str.into();
         if cursor_str.is_empty() {
             return Err("Cannot create a HS from an empty cursor".into());
         }
 
-        match cursor_str.parse() {
-            Ok(cursor) => Ok(Homeserver { id, cursor }),
-            Err(_) => Err("Cannot create a HS from a non-numeric cursor: {cursor_str}".into()),
-        }
+        let cursor = cursor_str
+            .parse()
+            .map_err(|_| format!("Cannot create a HS from a non-numeric cursor: {cursor_str}"))?;
+
+        Self::validate_cursor_change(&id, cursor).await?;
+
+        Ok(Homeserver { id, cursor })
     }
 
     /// Stores this homeserver in the graph.
     pub async fn put_to_graph(&self) -> Result<(), DynError> {
+        Self::validate_cursor_change(&self.id, self.cursor).await?;
+
         let query = queries::put::create_homeserver(&self.id);
         exec_single_row(query).await
     }
@@ -68,6 +77,8 @@ impl Homeserver {
 
     /// Stores this homeserver in Redis.
     pub async fn put_to_index(&self) -> Result<(), DynError> {
+        Self::validate_cursor_change(&self.id, self.cursor).await?;
+
         self.put_index_json(&[&self.id], None, None).await
     }
 
@@ -82,6 +93,17 @@ impl Homeserver {
                 None => Ok(None),
             },
         }
+    }
+
+    async fn validate_cursor_change(id: &str, new_cursor: u32) -> Result<(), DynError> {
+        // If we already indexed a value, reject cursors going below it to prevent reindexing past events
+        if let Some(hs_from_index) = Self::get_from_index(id).await? {
+            if new_cursor < hs_from_index.cursor {
+                return Err("Cursor cannot move backwards".into());
+            }
+        }
+
+        Ok(())
     }
 
     /// Verifies if homeserver exists in the graph, or persists it if missing

--- a/nexus-watcher/src/service/processor.rs
+++ b/nexus-watcher/src/service/processor.rs
@@ -110,7 +110,7 @@ impl EventProcessor {
 
             if let Some(cursor) = line.strip_prefix("cursor: ") {
                 info!("Received cursor for the next request: {cursor}");
-                match Homeserver::try_from_cursor(id, cursor) {
+                match Homeserver::try_from_cursor(id, cursor).await {
                     Ok(hs) => hs.put_to_index().await?,
                     Err(e) => warn!("{e}"),
                 }


### PR DESCRIPTION
This PR forbids updating a homeserver's cursor with a lower value, which prevents event reindexing.