### PR TITLE
Posts: do not update `indexed_at` on HS re-indexing

### DIFF
--- a/nexus-common/src/db/graph/queries/put.rs
+++ b/nexus-common/src/db/graph/queries/put.rs
@@ -62,8 +62,10 @@ pub fn create_post(
 
     cypher.push_str(
         "
+        // Set indexed_at only on creation
+        ON CREATE SET
+            new_post.indexed_at = $indexed_at
         SET new_post.content = $content,
-            new_post.indexed_at = $indexed_at,
             new_post.kind = $kind,
             new_post.attachments = $attachments
         RETURN existing_post IS NOT NULL AS flag",
@@ -77,10 +79,7 @@ pub fn create_post(
         .param("content", post.content.to_string())
         .param("indexed_at", post.indexed_at)
         .param("kind", kind.trim_matches('"'))
-        .param(
-            "attachments",
-            post.attachments.clone().unwrap_or(vec![] as Vec<String>),
-        );
+        .param("attachments", post.attachments.clone().unwrap_or(vec![]));
 
     // Handle "replied" relationship
     cypher_query = add_relationship_params(

--- a/nexus-common/src/models/post/details.rs
+++ b/nexus-common/src/models/post/details.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Represents post data with content, bio, image, links, and status.
-#[derive(Serialize, Deserialize, ToSchema, Default, Debug)]
+#[derive(Serialize, Deserialize, ToSchema, Default, Debug, PartialEq, Eq)]
 // NOTE: Might not be necessary the default values for serde because before PUT a PostDetails node
 // we do sanity check
 pub struct PostDetails {

--- a/nexus-watcher/tests/event_processor/posts/raw.rs
+++ b/nexus-watcher/tests/event_processor/posts/raw.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::utils::find_post_details;
 use super::utils::{
     check_member_global_timeline_user_post, check_member_user_post_timeline, find_post_counts,
@@ -5,9 +7,10 @@ use super::utils::{
 use crate::event_processor::users::utils::{check_member_user_influencer, find_user_counts};
 use crate::event_processor::utils::watcher::WatcherTest;
 use anyhow::Result;
+use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::post::{PostCounts, PostDetails};
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser, PubkyId};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_put_post_event() -> Result<()> {
@@ -60,6 +63,15 @@ async fn test_homeserver_put_post_event() -> Result<()> {
     assert_eq!(post_details.uri, post_detail_cache.uri);
     assert_eq!(post_details.indexed_at, post_detail_cache.indexed_at);
 
+    reindex_and_ensure_cache_and_graph_unchanged(
+        &mut test,
+        &post_details,
+        &post_detail_cache,
+        &user_id,
+        &post_id,
+    )
+    .await?;
+
     // User:Counts:user_id:post_id
     let post_counts: PostCounts = find_post_counts(&user_id, &post_id).await;
     assert_eq!(post_counts.reposts, 0);
@@ -98,6 +110,36 @@ async fn test_homeserver_put_post_event() -> Result<()> {
     //     .unwrap();
 
     // assert!(result_post.is_none(), "The post should have been deleted");
+
+    Ok(())
+}
+
+async fn reindex_and_ensure_cache_and_graph_unchanged(
+    test: &mut WatcherTest,
+    post_details_from_graph: &PostDetails,
+    post_detail_from_cache: &PostDetails,
+    user_id: &str,
+    post_id: &str,
+) -> Result<()> {
+    // Wait for a few ms, so that re-indexing determines a different indexed_at (epoch timestamp in ms)
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Reset the cursor, to ensure the events are re-indexed
+    let homeserver = Homeserver::new(PubkyId::try_from(&test.homeserver_id).unwrap());
+    homeserver.put_to_graph().await.unwrap();
+    homeserver.put_to_index().await.unwrap();
+    test.ensure_event_processing_complete().await?;
+
+    // Check that nothing changed in the graph (DB)
+    let post_details_2 = find_post_details(&user_id, &post_id).await.unwrap();
+    assert_eq!(post_details_from_graph, &post_details_2);
+
+    // Check that nothing changed in the index (cache)
+    let post_detail_cache_2: PostDetails = PostDetails::get_from_index(&user_id, &post_id)
+        .await
+        .unwrap()
+        .expect("The new post detail was not served from Nexus cache");
+    assert_eq!(post_detail_from_cache, &post_detail_cache_2);
 
     Ok(())
 }


### PR DESCRIPTION
Update the cypher query such that processing a `PUT post` event will only persist `indexed_at` on creation.

This means that, in case this event is processed (again) as part of a HS reindexing, `indexed_at`  is not updated. This is the only field that's updated in this case, so not updating it means the already existing post in the DB and cache is not altered.