### PR TITLE
Enforce RFC 3986 scheme-start rule in URI normalization fallback

### DIFF
--- a/nexus-common/src/models/resource/mod.rs
+++ b/nexus-common/src/models/resource/mod.rs
@@ -33,11 +33,12 @@ pub fn normalize_uri(uri: &str) -> Result<(String, String), String> {
             if let Some(colon_pos) = uri.find(':') {
                 let scheme = &uri[..colon_pos];
                 // Validate scheme: RFC 3986 §3.1 — ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-                if scheme.is_empty()
-                    || !scheme
-                        .bytes()
-                        .all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.')
-                {
+                let mut scheme_bytes = scheme.bytes();
+                let starts_with_alpha =
+                    scheme_bytes.next().is_some_and(|b| b.is_ascii_alphabetic());
+                let remainder_is_valid = scheme_bytes
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.');
+                if !starts_with_alpha || !remainder_is_valid {
                     return Err(format!("Invalid URI scheme: {uri}"));
                 }
                 let scheme_lower = scheme.to_ascii_lowercase();
@@ -226,6 +227,12 @@ mod tests {
     fn test_normalize_rejects_malformed_scheme() {
         // "ht tps" has a space — invalid per RFC 3986 §3.1
         assert!(normalize_uri("ht tps://example.com").is_err());
+    }
+
+    #[test]
+    fn test_normalize_rejects_scheme_starting_with_digit() {
+        // RFC 3986 §3.1 requires the first scheme character to be alphabetic.
+        assert!(normalize_uri("1ttp://example.com").is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The fallback path in `normalize_uri` previously accepted schemes that began with digits, which violates RFC 3986 §3.1 and could cause malformed URIs to be normalized instead of rejected.
- This change brings the fallback validation into alignment with the spec by ensuring the scheme starts with an ASCII letter.

### Description
- Tighten fallback validation in `normalize_uri` to require the first scheme byte be an ASCII alphabetic character and validate remaining bytes as `[A-Za-z0-9+-.]`.
- Preserve the existing parsing behavior for URIs that successfully parse with `Url::parse`, including lowercasing and normalization logic.
- Add a regression unit test `test_normalize_rejects_scheme_starting_with_digit` that asserts `normalize_uri("1ttp://example.com")` is rejected.

### Testing
- Ran `cargo test -p nexus-common test_normalize_rejects_scheme_starting_with_digit -- --exact`, which passed.
- Ran `cargo test -p nexus-common models::resource::tests::test_normalize_rejects_malformed_scheme`, which passed.
- Ran `cargo test -p nexus-common normalize_rejects_scheme_starting_with_digit`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0f507668832ca52df4d3dfc60f6c)