### PR TITLE
Scope TAGGED edges by app namespace for app-specific tag operations

### DIFF
--- a/nexus-common/src/db/graph/queries/put.rs
+++ b/nexus-common/src/db/graph/queries/put.rs
@@ -221,6 +221,10 @@ pub fn create_post_bookmark(
 /// * `tag_id` - A unique identifier for the tagging relationship.
 /// * `label` - A string representing the label of the tag.
 /// * `indexed_at` - A timestamp representing when the tagging relationship was created or last updated.
+/// * `app` - The app namespace the tag was created from (e.g., "mapky"). When `Some`, the
+///   `app` property is included in the matched/merged TAGGED relationship so that tag deletion
+///   scoped to the same app can locate the edge. When `None`, no `app` property is set, which
+///   matches the behavior for standard pubky.app tags.
 ///
 pub fn create_post_tag(
     user_id: &str,
@@ -229,26 +233,42 @@ pub fn create_post_tag(
     tag_id: &str,
     label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Query {
-    Query::new(
-        "create_post_tag",
-        "MATCH (user:User {id: $user_id})
+    // `app` is part of the MERGE pattern so the edge identity is scoped to the
+    // app namespace — preventing one app's TAGGED edge from being matched
+    // (and thus re-used or deleted) by another app with the same tag_id.
+    let rel_props = match app {
+        Some(_) => "{label: $label, app: $app}",
+        None => "{label: $label}",
+    };
+
+    let cypher = format!(
+        "MATCH (user:User {{id: $user_id}})
         // We assume these nodes are already created. If not we would not be able to add a tag
-        MATCH (author:User {id: $author_id})-[:AUTHORED]->(post:Post {id: $post_id})
+        MATCH (author:User {{id: $author_id}})-[:AUTHORED]->(post:Post {{id: $post_id}})
         // Check if tag already existed
-        OPTIONAL MATCH (user)-[existing:TAGGED {label: $label}]->(post)
-        MERGE (user)-[t:TAGGED {label: $label}]->(post)
+        OPTIONAL MATCH (user)-[existing:TAGGED {rel_props}]->(post)
+        MERGE (user)-[t:TAGGED {rel_props}]->(post)
         ON CREATE SET t.indexed_at = $indexed_at,
                       t.id = $tag_id
         // Returns true if the post tag relationship already existed
-        RETURN existing IS NOT NULL AS flag;",
-    )
-    .param("user_id", user_id)
-    .param("author_id", author_id)
-    .param("post_id", post_id)
-    .param("tag_id", tag_id)
-    .param("label", label)
-    .param("indexed_at", indexed_at)
+        RETURN existing IS NOT NULL AS flag;"
+    );
+
+    let mut query = Query::new("create_post_tag", &cypher)
+        .param("user_id", user_id)
+        .param("author_id", author_id)
+        .param("post_id", post_id)
+        .param("tag_id", tag_id)
+        .param("label", label)
+        .param("indexed_at", indexed_at);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
 }
 
 /// Creates a `TAGGED` relationship between two users. The relationship is uniquely identified by a `label`
@@ -258,30 +278,50 @@ pub fn create_post_tag(
 /// * `tag_id` - A unique identifier for the tagging relationship.
 /// * `label` - A string representing the label of the tag.
 /// * `indexed_at` - A timestamp indicating when the tagging relationship was created or last updated.
+/// * `app` - The app namespace the tag was created from (e.g., "mapky"). When `Some`, the
+///   `app` property is included in the matched/merged TAGGED relationship so that tag deletion
+///   scoped to the same app can locate the edge. When `None`, no `app` property is set, which
+///   matches the behavior for standard pubky.app tags.
 pub fn create_user_tag(
     tagger_user_id: &str,
     tagged_user_id: &str,
     tag_id: &str,
     label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Query {
-    Query::new(
-        "create_user_tag",
-        "MATCH (tagged_used:User {id: $tagged_user_id})
-        MATCH (tagger:User {id: $tagger_user_id})
+    // `app` is part of the MERGE pattern so the edge identity is scoped to the
+    // app namespace — preventing one app's TAGGED edge from being matched
+    // (and thus re-used or deleted) by another app with the same tag_id.
+    let rel_props = match app {
+        Some(_) => "{label: $label, app: $app}",
+        None => "{label: $label}",
+    };
+
+    let cypher = format!(
+        "MATCH (tagged_used:User {{id: $tagged_user_id}})
+        MATCH (tagger:User {{id: $tagger_user_id}})
         // Check if tag already existed
-        OPTIONAL MATCH (tagger)-[existing:TAGGED {label: $label}]->(tagged_used)
-        MERGE (tagger)-[t:TAGGED {label: $label}]->(tagged_used)
+        OPTIONAL MATCH (tagger)-[existing:TAGGED {rel_props}]->(tagged_used)
+        MERGE (tagger)-[t:TAGGED {rel_props}]->(tagged_used)
         ON CREATE SET t.indexed_at = $indexed_at,
                       t.id = $tag_id
         // Returns true if the user tag relationship already existed
-        RETURN existing IS NOT NULL AS flag;",
-    )
-    .param("tagger_user_id", tagger_user_id)
-    .param("tagged_user_id", tagged_user_id)
-    .param("tag_id", tag_id)
-    .param("label", label)
-    .param("indexed_at", indexed_at)
+        RETURN existing IS NOT NULL AS flag;"
+    );
+
+    let mut query = Query::new("create_user_tag", &cypher)
+        .param("tagger_user_id", tagger_user_id)
+        .param("tagged_user_id", tagged_user_id)
+        .param("tag_id", tag_id)
+        .param("label", label)
+        .param("indexed_at", indexed_at);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
 }
 
 /// Creates a `TAGGED` relationship between a user and a generic Resource node.

--- a/nexus-common/src/models/tag/traits/collection.rs
+++ b/nexus-common/src/models/tag/traits/collection.rs
@@ -317,6 +317,10 @@ where
     /// - `label` - A string slice representing the label of the tag.
     /// - `indexed_at` - A 64-bit integer representing the timestamp (milliseconds)
     ///   when the tag was indexed.
+    /// - `app` - The app namespace the tag was created from (e.g., "mapky") when the tag
+    ///   originates from an app-specific path. When `Some`, the `app` property is set on
+    ///   the TAGGED edge so that subsequent app-scoped deletes can locate it. When `None`,
+    ///   no `app` property is stored — matching the standard pubky.app tag behavior.
     async fn put_to_graph(
         tagger_user_id: &str,
         tagged_user_id: &str,
@@ -324,6 +328,7 @@ where
         tag_id: &str,
         label: &str,
         indexed_at: i64,
+        app: Option<&str>,
     ) -> GraphResult<OperationOutcome> {
         let query = match extra_param {
             Some(post_id) => queries::put::create_post_tag(
@@ -333,6 +338,7 @@ where
                 tag_id,
                 label,
                 indexed_at,
+                app,
             ),
             None => queries::put::create_user_tag(
                 tagger_user_id,
@@ -340,6 +346,7 @@ where
                 tag_id,
                 label,
                 indexed_at,
+                app,
             ),
         };
         execute_graph_operation(query).await

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -28,6 +28,15 @@ pub async fn sync_put(
     tagger_id: PubkyId,
     tag_id: String,
 ) -> Result<(), EventProcessorError> {
+    sync_put_inner(tag, tagger_id, tag_id, None).await
+}
+
+async fn sync_put_inner(
+    tag: PubkyAppTag,
+    tagger_id: PubkyId,
+    tag_id: String,
+    app: Option<&str>,
+) -> Result<(), EventProcessorError> {
     debug!("Indexing new tag: {} -> {}", tagger_id, tag_id);
 
     // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
@@ -40,12 +49,14 @@ pub async fn sync_put(
         Resource::Post(post_id) => {
             // Place the tag on post
             put_sync_post(
-                tagger_id, user_id, &post_id, &tag_id, &tag.label, &tag.uri, indexed_at,
+                tagger_id, user_id, &post_id, &tag_id, &tag.label, &tag.uri, indexed_at, app,
             )
             .await
         }
         // If no post_id in the tagged URI, we place tag to a user.
-        Resource::User => put_sync_user(tagger_id, user_id, &tag_id, &tag.label, indexed_at).await,
+        Resource::User => {
+            put_sync_user(tagger_id, user_id, &tag_id, &tag.label, indexed_at, app).await
+        }
         other => Err(EventProcessorError::generic(format!(
             "The tagged resource is not Post or User, instead is: {other:?}"
         ))),
@@ -69,8 +80,11 @@ pub async fn sync_put_resource(
     let category = classify_uri(&tag.uri);
     match category {
         UriCategory::InternalKnown => {
-            // The tagged URI is a known Post/User — delegate to existing flow
-            sync_put(tag, tagger_id, tag_id).await
+            // The tagged URI is a known Post/User — delegate to existing flow,
+            // but propagate `app` so the TAGGED edge carries the app namespace.
+            // Without this, the symmetric DEL path (which passes Some(app)) would
+            // fail to locate the edge and silently no-op.
+            sync_put_inner(tag, tagger_id, tag_id, Some(&app)).await
         }
         UriCategory::InternalUnknown | UriCategory::External => {
             let (normalized, scheme) =
@@ -193,6 +207,7 @@ async fn put_sync_resource(
 /// - `post_uri` - A `String` representing the homeserver URI of the tagged post.
 /// - `indexed_at` - A 64-bit integer representing the timestamp when the post was indexed.
 ///
+#[allow(clippy::too_many_arguments)]
 async fn put_sync_post(
     tagger_user_id: PubkyId,
     author_id: PubkyId,
@@ -201,6 +216,7 @@ async fn put_sync_post(
     tag_label: &str,
     post_uri: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Result<(), EventProcessorError> {
     match TagPost::put_to_graph(
         &tagger_user_id,
@@ -209,6 +225,7 @@ async fn put_sync_post(
         tag_id,
         tag_label,
         indexed_at,
+        app,
     )
     .await?
     {
@@ -321,6 +338,7 @@ async fn put_sync_user(
     tag_id: &str,
     tag_label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Result<(), EventProcessorError> {
     match TagUser::put_to_graph(
         &tagger_user_id,
@@ -329,6 +347,7 @@ async fn put_sync_user(
         tag_id,
         tag_label,
         indexed_at,
+        app,
     )
     .await?
     {

--- a/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
@@ -63,6 +63,7 @@ async fn test_tag_post_del_retry_no_double_decrement() -> Result<()> {
         tag_id,
         label,
         OLD_INDEXED_AT,
+        None,
     )
     .await?;
     assert!(matches!(outcome, OperationOutcome::CreatedOrDeleted));
@@ -153,6 +154,7 @@ async fn test_tag_post_del_replay_after_success_skips() -> Result<()> {
         tag_id,
         label,
         OLD_INDEXED_AT,
+        None,
     )
     .await?;
     TagPost::add_tagger_to_index(&author_id, Some(&post_id), &tagger_id, label).await?;

--- a/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
@@ -70,8 +70,18 @@ async fn test_resource_tag_internal_known_delegates_to_post() -> Result<()> {
         "InternalKnown URI should NOT create a Resource node"
     );
 
-    // Cleanup
+    // Regression: deleting the universal tag at the app-specific path must
+    // actually remove the TAGGED edge. The DEL handler scopes the lookup by
+    // `app`, so the PUT must persist the same `app` namespace on the edge.
     test.del(&user_kp, &custom_path).await?;
+
+    let post_tag_after_del = find_post_tag(&user_id, &post_id, label).await?;
+    assert!(
+        post_tag_after_del.is_none(),
+        "Universal tag DEL on InternalKnown URI should remove the TAGGED edge"
+    );
+
+    // Cleanup
     test.cleanup_post(&user_kp, &post_path).await?;
     test.cleanup_user(&user_kp).await?;
 


### PR DESCRIPTION
## Description

This PR adds support for scoping tag operations to specific app namespaces. When tags are created from app-specific paths (e.g., `mapky`), the `app` property is now persisted on the `TAGGED` relationship in the graph. This ensures that subsequent delete operations scoped to the same app can correctly locate and remove the edge.

### Changes

**nexus-common/src/db/graph/queries/put.rs**
- Updated `create_post_tag()` and `create_user_tag()` to accept an optional `app` parameter
- Modified Cypher queries to conditionally include the `app` property in the MERGE pattern when provided
- The `app` property becomes part of the edge identity, preventing one app's tags from being matched or deleted by another app with the same `tag_id`

**nexus-watcher/src/events/handlers/tag.rs**
- Refactored `sync_put()` to delegate to a new `sync_put_inner()` function that accepts the `app` parameter
- Updated `sync_put_resource()` to propagate the `app` namespace when delegating to the internal known resource flow
- Modified `put_sync_post()` and `put_sync_user()` to accept and forward the `app` parameter to graph operations

**nexus-common/src/models/tag/traits/collection.rs**
- Updated `put_to_graph()` trait method to accept an optional `app` parameter
- Forwards the `app` parameter to both `create_post_tag()` and `create_user_tag()` queries

**nexus-watcher/tests/event_processor/tags/**
- Added regression test in `resource_internal_known.rs` to verify that universal tags created via app-specific paths can be deleted correctly
- Updated existing tests in `del_idempotent.rs` to pass `None` for the `app` parameter

### Motivation

Previously, tags created from app-specific paths were stored without an `app` property on the TAGGED edge. This caused a mismatch when the delete handler (which scopes lookups by `app`) attempted to remove the edge—it would fail to locate it and silently no-op, leaving orphaned tags in the graph.

By including the `app` namespace in the edge identity during creation, the symmetric delete path can now correctly locate and remove app-scoped tags.

## Testing

- Added regression test verifying that universal tags created via app-specific paths are properly deleted
- Updated existing tests to pass the new `app` parameter
- All tests pass with `cargo nextest run`
